### PR TITLE
make running the app for local development easier.

### DIFF
--- a/fakebook/src/app/app.module.ts
+++ b/fakebook/src/app/app.module.ts
@@ -25,9 +25,9 @@ import { PostFormComponent } from './component/post-form/post-form.component';
 export class TimeAgoExtendsPipe extends TimeAgoPipe implements PipeTransform {}
 
 const config = {
-  issuer: 'https://dev-2875280.okta.com/oauth2/default',
+  issuer: 'https://revature-p3.okta.com/oauth2/default',
   pkce: true,
-  clientId: '0oa3g3amkeK6iIIeP5d6',
+  clientId: '0oafgszgmBjYO7PPh5d6',
   redirectUri: `${window.location.origin}/login/callback`,
   scopes: ['openid'],
   postLogoutRedirectUri: window.location.origin,

--- a/fakebook/src/app/service/comment.service.ts
+++ b/fakebook/src/app/service/comment.service.ts
@@ -9,7 +9,7 @@ import { Post } from '../model/post';
   providedIn: 'root',
 })
 export class CommentService {
-  url = `${environment.baseUrl}/api/comments`;
+  url = `${environment.baseUrls.posts}/api/comments`;
 
   constructor(private oktaAuth: OktaAuthService, private http: HttpClient) {}
 

--- a/fakebook/src/app/service/follow.service.ts
+++ b/fakebook/src/app/service/follow.service.ts
@@ -10,7 +10,7 @@ import { FnParam } from '@angular/compiler/src/output/output_ast';
 })
 export class FollowService {
   constructor(private http: HttpClient, private oktaAuth: OktaAuthService) {}
-  url = `${environment.baseUrl}/api`;
+  url = `${environment.baseUrls.posts}/api`;
 
   follow(follower: User, followee: User): any {
     const accessToken = this.oktaAuth.getAccessToken();

--- a/fakebook/src/app/service/like.service.ts
+++ b/fakebook/src/app/service/like.service.ts
@@ -8,7 +8,7 @@ import { environment } from 'src/environments/environment';
   providedIn: 'root',
 })
 export class LikeService {
-  url = `${environment.baseUrl}/api/`;
+  url = `${environment.baseUrls.posts}/api/`;
 
   constructor(private http: HttpClient, private oktaAuth: OktaAuthService) {}
 

--- a/fakebook/src/app/service/newsfeed.service.spec.ts
+++ b/fakebook/src/app/service/newsfeed.service.spec.ts
@@ -22,7 +22,7 @@ describe('NewsfeedService', () => {
   let service: NewsfeedService;
   let httpClientSpy: { get: jasmine.Spy };
   let httpTestingController: HttpTestingController;
-  const url = `${environment.baseUrl}`;
+  const url = `${environment.baseUrls.posts}`;
 
   beforeEach(() => {
     const mockOktaAuthService = {
@@ -65,6 +65,6 @@ describe('NewsfeedService', () => {
   });
 
   it('should have the correct urls', () => {
-    expect(service.url).toBe(environment.baseUrl);
+    expect(service.url).toBe(environment.baseUrls.posts);
   });
 });

--- a/fakebook/src/app/service/newsfeed.service.spec.ts
+++ b/fakebook/src/app/service/newsfeed.service.spec.ts
@@ -63,8 +63,4 @@ describe('NewsfeedService', () => {
     expect(service.headers.Authorization).toBe('Bearer 0');
     expect(service.headers.Accept).toBe('application/json');
   });
-
-  it('should have the correct urls', () => {
-    expect(service.url).toBe(environment.baseUrls.posts);
-  });
 });

--- a/fakebook/src/app/service/newsfeed.service.ts
+++ b/fakebook/src/app/service/newsfeed.service.ts
@@ -11,7 +11,6 @@ import { environment } from '../../environments/environment';
 })
 export class NewsfeedService {
   constructor(private http: HttpClient, private oktaAuth: OktaAuthService) {}
-  url = `${environment.baseUrls.posts}`;
 
   headers = {
     Authorization: 'Bearer ' + this.oktaAuth.getAccessToken(),
@@ -24,7 +23,10 @@ export class NewsfeedService {
       Authorization: 'Bearer ' + accessToken,
       Accept: 'application/json',
     };
-    return this.http.get<Post[]>(`${this.url}/api/posts/newsfeed`, { headers });
+    return this.http.get<Post[]>(
+      `${environment.baseUrls.posts}/api/posts/newsfeed`,
+      { headers }
+    );
   }
 
   getUser(): Observable<User> {
@@ -33,6 +35,8 @@ export class NewsfeedService {
       Authorization: 'Bearer ' + accessToken,
       Accept: 'application/json',
     };
-    return this.http.get<User>(`${this.url}/api/profiles/`, { headers });
+    return this.http.get<User>(`${environment.baseUrls.profile}/api/profiles/`, {
+      headers,
+    });
   }
 }

--- a/fakebook/src/app/service/newsfeed.service.ts
+++ b/fakebook/src/app/service/newsfeed.service.ts
@@ -11,7 +11,7 @@ import { environment } from '../../environments/environment';
 })
 export class NewsfeedService {
   constructor(private http: HttpClient, private oktaAuth: OktaAuthService) {}
-  url = `${environment.baseUrl}`;
+  url = `${environment.baseUrls.posts}`;
 
   headers = {
     Authorization: 'Bearer ' + this.oktaAuth.getAccessToken(),

--- a/fakebook/src/app/service/notifications.service.ts
+++ b/fakebook/src/app/service/notifications.service.ts
@@ -39,7 +39,7 @@ export class NotificationsService {
 
     // Start hub connection to SignalR
     this.hubConnection = new HubConnectionBuilder()
-      .withUrl(`${environment.baseUrl}/notifications`, options)
+      .withUrl(`${environment.baseUrls.notifications}/notifications`, options)
       .build();
     this.hubConnection
       .start()

--- a/fakebook/src/app/service/post.service.spec.ts
+++ b/fakebook/src/app/service/post.service.spec.ts
@@ -65,6 +65,6 @@ describe('PostService', () => {
   });
 
   it('should have the correct urls', () => {
-    expect(service.url).toBe(`${environment.baseUrl}/api/posts`);
+    expect(service.url).toBe(`${environment.baseUrls.posts}/api/posts`);
   });
 });

--- a/fakebook/src/app/service/post.service.ts
+++ b/fakebook/src/app/service/post.service.ts
@@ -11,7 +11,7 @@ import { NewPost } from '../model/newpost';
 })
 export class PostService {
   constructor(private http: HttpClient, private oktaAuth: OktaAuthService) {}
-  url = `${environment.baseUrl}/api/posts`;
+  url = `${environment.baseUrls.posts}/api/posts`;
 
   headers = {
     headers: {

--- a/fakebook/src/app/service/profile.service.spec.ts
+++ b/fakebook/src/app/service/profile.service.spec.ts
@@ -31,6 +31,6 @@ describe('ProfileService', () => {
       TestBed.inject(OktaAuthService)
     );
     expect(service).toBeTruthy();
-    expect(service.baseUrl).toBe(`${environment.baseUrl}/api/profiles/`);
+    expect(service.baseUrl).toBe(`${environment.baseUrls.profile}/api/profiles/`);
   });
 });

--- a/fakebook/src/app/service/profile.service.ts
+++ b/fakebook/src/app/service/profile.service.ts
@@ -10,7 +10,7 @@ import { Post } from '../model/post';
   providedIn: 'root',
 })
 export class ProfileService {
-  baseUrl = `${environment.baseUrl}/api/profiles/`;
+  baseUrl = `${environment.baseUrls.profile}/api/profiles/`;
 
   constructor(public http: HttpClient, private oktaAuth: OktaAuthService) {}
 

--- a/fakebook/src/app/service/upload-image.service.spec.ts
+++ b/fakebook/src/app/service/upload-image.service.spec.ts
@@ -30,6 +30,6 @@ describe('UploadImageService', () => {
       TestBed.inject(OktaAuthService)
     );
     expect(service).toBeTruthy();
-    expect(service.url).toBe(`${environment.baseUrl}/api/profiles/`);
+    expect(service.url).toBe(`${environment.baseUrls.profile}/api/profiles/`);
   });
 });

--- a/fakebook/src/app/service/upload-image.service.ts
+++ b/fakebook/src/app/service/upload-image.service.ts
@@ -7,7 +7,7 @@ import { environment } from 'src/environments/environment';
   providedIn: 'root',
 })
 export class UploadImageService {
-  url = `${environment.baseUrl}/api/profiles/`;
+  url = `${environment.baseUrls.profile}/api/profiles/`;
 
   constructor(private http: HttpClient, private oktaAuth: OktaAuthService) {}
 
@@ -20,7 +20,7 @@ export class UploadImageService {
 
     return this.http
       .post<{ path: string; userId: number }>(
-        `${environment.baseUrl}/api/ProfilePicture`,
+        `${environment.baseUrls.profile}/api/ProfilePicture`,
         formData,
         headers
       )

--- a/fakebook/src/app/service/upload.service.ts
+++ b/fakebook/src/app/service/upload.service.ts
@@ -9,7 +9,7 @@ export class UploadService {
   upload(formData: FormData): Promise<any> {
     return this.http
       .post<{ path: string; userId: number }>(
-        `${environment.baseUrl}/api/Posts/UploadPicture`,
+        `${environment.baseUrls.posts}/api/Posts/UploadPicture`,
         formData
       )
       .toPromise();

--- a/fakebook/src/environments/environment.prod.ts
+++ b/fakebook/src/environments/environment.prod.ts
@@ -1,4 +1,10 @@
+const clusterBaseUrl = 'https://fakebook.revaturelabs.com';
+
 export const environment = {
   production: true,
-  baseUrl: 'https://fakebook.revaturelabs.com',
+  baseUrls: {
+    posts: clusterBaseUrl,
+    notifications: clusterBaseUrl,
+    profile: clusterBaseUrl,
+  },
 };

--- a/fakebook/src/environments/environment.ts
+++ b/fakebook/src/environments/environment.ts
@@ -4,7 +4,11 @@
 
 export const environment = {
   production: false,
-  baseUrl: 'https://fakebook.revaturelabs.com',
+  baseUrls: {
+    posts: 'https://localhost:44366',
+    notifications: 'https://localhost:44345',
+    profile: 'https://localhost:44362',
+  },
 };
 
 /*


### PR DESCRIPTION
- replace old okta configuration with new okta configuration (https://revature-p3-admin.okta.com/)
- refactor use of `environment.baseUrl` to support different base URLs for the three backend services, which is needed in local development since they will be on different ports.
  - (not needed in the cluster because of the ingress defined in `kubernetes_ingresses.yaml`).

cf. https://github.com/2011-fakebook-project3/profile/pull/36, https://github.com/2011-fakebook-project3/posts/pull/114, https://github.com/2011-fakebook-project3/notifications/pull/47