### PR TITLE
updates newsfeed when a post is made

### DIFF
--- a/fakebook/src/app/component/newsfeed/newsfeed.component.html
+++ b/fakebook/src/app/component/newsfeed/newsfeed.component.html
@@ -23,7 +23,7 @@
       </div>
     </div>
     <div class="col-md-6">
-      <app-new-post-form [user]="user"></app-new-post-form>
+      <app-new-post-form [user]="user" (updatePage) = "getPosts(true)"></app-new-post-form>
       <div *ngFor="let post of posts">
         <app-post-view
           [post]="post"

--- a/fakebook/src/app/component/post-form/post-form.component.ts
+++ b/fakebook/src/app/component/post-form/post-form.component.ts
@@ -12,6 +12,7 @@ import { ProfileService } from '../../services/profile.service';
 import { NewPost } from '../../model/newpost';
 import { PostService } from '../../services/post.service';
 import { UploadService } from '../../services/upload.service';
+import { Post } from '../../model/post';
 
 @Component({
   selector: 'app-new-post-form',
@@ -23,13 +24,14 @@ export class PostFormComponent {
   submitted = false;
   file: File | null = null;
   imageSource = '';
-  newPost = new NewPost('', '', ''); // we'll initialize user id at onsubmit
+  @Input() newPost = new NewPost('', '', ''); // we'll initialize user id at onsubmit
 
   @ViewChild('fileInput') fileInputRef!: ElementRef;
 
   @Input() user: User | null = null;
 
   @Output() notify: EventEmitter<string> = new EventEmitter<string>();
+  @Output() updatePage: EventEmitter<Post> = new EventEmitter<Post>(); //
 
   constructor(
     private uploadService: UploadService,
@@ -48,7 +50,7 @@ export class PostFormComponent {
           this.newPost.userId = this.user?.email;
           this.submitted = true;
           this.httpPost.create(this.newPost).then((result) => {
-            return this.notify.emit('test value from child');
+            return this.updatePage.emit(result);
           });
 
           this.newPost.content = '';
@@ -63,7 +65,7 @@ export class PostFormComponent {
       this.submitted = true;
       this.httpPost
         .create(this.newPost)
-        .then((res) => this.notify.emit('test value from child'));
+        .then((res) => this.updatePage.emit(res));
     }
   }
 

--- a/fakebook/src/app/services/post.service.ts
+++ b/fakebook/src/app/services/post.service.ts
@@ -12,8 +12,8 @@ export class PostService {
   constructor(private http: HttpClient) {}
   url = `${environment.baseUrls.posts}/api/posts`;
 
-  create(post: NewPost): Promise<NewPost> {
-    return this.http.post<NewPost>(`${this.url}`, post).toPromise();
+  create(post: NewPost): Promise<Post> {
+    return this.http.post<Post>(`${this.url}`, post).toPromise();
   }
 
   likePost(id: number): Observable<Post> {


### PR DESCRIPTION
when you make a new post, the Newsfeed will refresh and add the post to the top without having to press 'refresh' or tab over into profile and back to newsfeed.

this is done through an eventListener that emits Post in the PostForm. The newsfeed HTML will take the updatePage eventemitter from PostForm and use GetPosts method in NewsFeed to update the Newsfeed.