### PR TITLE
fix url in in comment service to return the correct url instead of the same url twice.

### DIFF
--- a/fakebook/src/app/services/comment.service.ts
+++ b/fakebook/src/app/services/comment.service.ts
@@ -15,19 +15,19 @@ export class CommentService {
   constructor(private http: HttpClient) {}
 
   create(comment: NewComment): Promise<NewComment> {
-    const targetUrl = `/${this.url}`;
+    const targetUrl = `${this.url}`;
 
     return this.http.post<Comment>(targetUrl, comment).toPromise();
   }
 
   delete(comment: Comment): Promise<number> {
-    const targetUrl = `/${this.url}/${comment.id}`;
+    const targetUrl = `${this.url}/${comment.id}`;
 
     return this.http.delete<number>(targetUrl).toPromise();
   }
 
   get(commentId: number): Promise<Comment> {
-    const targetUrl = `/${this.url}/${commentId}`;
+    const targetUrl = `${this.url}/${commentId}`;
 
     return this.http.get<Comment>(targetUrl).toPromise();
   }


### PR DESCRIPTION
The slash inside of the comment service was making the url be applied twice, which resulted in a page not found error (404 status code). Once i erased the slash, the url was only appended once, and it fixed the 404 error.