### PR TITLE
Fixed profile name not appearing in comments.

### DIFF
--- a/fakebook/src/app/component/comment-view/comment-view.component.ts
+++ b/fakebook/src/app/component/comment-view/comment-view.component.ts
@@ -27,8 +27,10 @@ export class CommentViewComponent implements OnInit {
   ngOnInit(): void {
     if (this.commentAndUserExist(this.comment)) {
       this.profileService.GetProfile(this.comment?.userEmail ?? '').subscribe(
-        (prof) => (this.user.profilePictureUrl = prof.profilePictureUrl ?? ''),
-        (prof) => (this.user.fullname = prof.firstName + ' ' + prof.lastName)
+        (prof) => {
+          this.user.profilePictureUrl = prof.profilePictureUrl ?? '';
+          this.user.fullname = prof.firstName + ' ' + prof.lastName;
+        }
       );
     }
   }


### PR DESCRIPTION
The comments previously did not show the name of the user who comment; now it does. The previous implementation was using the wrong method overload so that the name would only be set if getting the user failed.